### PR TITLE
Update omniauth-oauth gem to v2.0

### DIFF
--- a/omniauth-intuit.gemspec
+++ b/omniauth-intuit.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency 'omniauth-oauth', '~> 1.0.0'
+  s.add_runtime_dependency 'omniauth-oauth', '~> 2~.0.0'
 
   s.add_development_dependency 'rspec', '~> 2.7.0'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
Update the `omniauth-oauth` gem to v2.0 to resolve a version dependency problem between the `omniauth`
and `omniauth-intuit` gems.